### PR TITLE
define ReactNative

### DIFF
--- a/boilerplate/index.js.ejs
+++ b/boilerplate/index.js.ejs
@@ -1,5 +1,5 @@
 import './js/App/Config/ReactotronConfig'
-import { AppRegistry, YellowBox } from 'react-native'
+import ReactNative, { AppRegistry, YellowBox } from 'react-native'
 import App from './js/App/Containers/App'
 
 YellowBox.ignoreWarnings(['Require cycle:']);


### PR DESCRIPTION
solves:

```
ReferenceError: ReactNative is not defined
    at index.js:8
    at loadModuleImplementation (require.js:319)
    at guardedLoadModule (require.js:207)
    at metroRequire (require.js:136)
    at blob:http://localhost:8081/72c88d91-1386-45ff-a03b-c85bf4ee5405:142138
    at executeApplicationScript (debuggerWorker.js:40)
    at debuggerWorker.js:65
```